### PR TITLE
Update 3c_fw_flashing.md

### DIFF
--- a/_docs/3c_fw_flashing.md
+++ b/_docs/3c_fw_flashing.md
@@ -18,13 +18,13 @@ For the boards with Cortex connector, we recommend to order [this adapter PCB](h
 
 ### SWD pin header
 
-The Libre Solar boards contain a 6-pin header with exactly the same pin-out as the SWD connector on the ST-Link/V2 of the Nucleo boards. In addition to that, you can use the serial interface built-in to the Nucleo board to transfer debug information via an additional 2-pin connector.
+The Libre Solar boards usually contain a 5-pin or 6-pin header with the same pin-out as the SWD connector on the ST-Link/V2 of the Nucleo boards. In addition to that, you can use the **serial interface** built-in to the Nucleo board to transfer debug information via an additional 2-pin connector.
 
 Before you can flash the software, the device needs to be powered, either via USB or the battery.
 
 For the serial wire debug (SWD) interface just connect the same pins of the SWD connector of both boards. The following table gives an overview of the connector pinout:
 
-| Pin function   | Nucleo board | Libre Solar board |
+| Pin function   | Nucleo board (CN4) | Libre Solar board |
 |----------------|--------------|-------------------|
 | VCC            | SWD pin 1    | SWD pin 1         |
 | SWCLK          | SWD pin 2    | SWD pin 2         |


### PR DESCRIPTION
Made the documentation closer match with https://github.com/LibreSolar/learn.libre.solar/edit/master/docs/development/flashing_debugging.md
I understand https://libre.solar/docs/ as a place for professionals/hobbyist and learn.libre.solar for newcomers and students. Therefor, libre.solar/docs it more compact, still one might try to merge both in a way that learn.libre.solar is based on libre.solar/docs, thus one does not have to keep both up to date. 

Either way, heads up Martin the documentation is great and helped me a lot on my journey so far.

Another improvement would be to display [Edit this page on GitHub!](https://github.com/LibreSolar/libresolar.github.io/blob/master/_docs/3c_fw_flashing.md) on the bottom of the page as it is done in https://learn.libre.solar/development/flashing_debugging.html#debugging. As it makes contributing improvements to the page much more accessible. 